### PR TITLE
 added stk transaction validation, and test case

### DIFF
--- a/test/ex_pesa/Mpesa/stk_test.exs
+++ b/test/ex_pesa/Mpesa/stk_test.exs
@@ -34,12 +34,26 @@ defmodule ExPesa.Mpesa.StkTest do
               "ResponseDescription" => "Success. Request accepted for processing"
             })
         }
+
+      %{url: "https://sandbox.safaricom.co.ke/mpesa/stkpushquery/v1/query", method: :post} ->
+        %Tesla.Env{
+          status: 200,
+          body:
+            Jason.encode!(%{
+              "CheckoutRequestID" => "ws_CO_260820202102496165",
+              "MerchantRequestID" => "11130-78831728-4",
+              "ResponseCode" => "0",
+              "ResponseDescription" => "The service request has been accepted successsfully",
+              "ResultCode" => "1032",
+              "ResultDesc" => "Request cancelled by user"
+            })
+        }
     end)
 
     :ok
   end
 
-  describe "Mpesa STK Push" do
+  describe "Mpesa STK Push/ Validate Transaction" do
     test "request/1 should Initiate STK with required parameters" do
       request_details = %{
         amount: 10,
@@ -58,5 +72,18 @@ defmodule ExPesa.Mpesa.StkTest do
   test "request/1 should error out without required parameter" do
     {:error, result} = Stk.request(%{})
     "Required Parameters missing, 'phone, 'amount', 'reference', 'description'" = result
+  end
+
+  test "validate/1 should validate transaction successfully" do
+    {:ok, result} = Stk.validate(%{checkout_request_id: "ws_CO_260820202102496165"})
+
+    assert result["CheckoutRequestID"] == "ws_CO_260820202102496165"
+    assert result["ResponseCode"] == "0"
+    assert result["ResultDesc"] == "Request cancelled by user"
+  end
+
+  test "validate/1 should error out without required parameter" do
+    {:error, result} = Stk.validate(%{})
+    "Required Parameter missing, 'CheckoutRequestID'" = result
   end
 end


### PR DESCRIPTION
## What is the Purpose?

Added STK Transaction Validation

### to test
`ExPesa.Mpesa.Stk.validate(%{checkout_request_id: "ws_CO_260820202102496165"})`
replace the `checkout_request_id` with a valid `CheckoutRequestID`. you can get one by initiating an STK push from the already existing STK push like below;
`ExPesa.Mpesa.Stk.request(%{amount: 10, phone: "254724540000", reference: "reference", description: "description"})`
