### PR TITLE
 added account balance

### DIFF
--- a/config/dev.sample.exs
+++ b/config/dev.sample.exs
@@ -24,6 +24,7 @@ config :ex_pesa,
         "kxlZ1Twlfr6xQru0GId03LbegvuTPelnz3qITkvUJxaCTQt1HaD2hN801Pgbi38x6dEq/hsanBBtfj6JbePayipE/srOyMQ61ieiO+5uHb/JX/NLi1Jy6Alvi0hKbCbq9cVwC/bZBhli7AUAtpfKVgIyXq2InNyfzXpzR8FhrbXiaMhTPJ8WleozPm5CnXe2bFlFP7K0yhCRlT+UOPl7xh0LqU23rMTj3TN/ms600c3j/m2FxQZdmY5/rdORrJeTQV1vw6kXr1QrGaSDSdRMUiaGbg5uPL8LSNwC5bn3M92oPY2cWmkyH9rOzbCN+o5+23TvweaKZlrKuv7etKXMFg=="
     ],
     balance: [
+      short_code: "602843",
       initiator_name: "Safaricom1",
       password: "Safaricom133",
       timeout_url: "https://58cb49b30213.ngrok.io/b2b/timeout_url",

--- a/config/test.exs
+++ b/config/test.exs
@@ -19,5 +19,14 @@ config :ex_pesa,
       result_url: "https://58cb49b30213.ngrok.io/b2b/result_url",
       #   Leace blank to increase util test coverage
       security_credential: ""
+    ],
+    balance: [
+      short_code: "600247",
+      initiator_name: "Safaricom1",
+      password: "Safaricom133",
+      timeout_url: "https://58cb49b30213.ngrok.io/b2b/timeout_url",
+      result_url: "https://58cb49b30213.ngrok.io/b2b/result_url",
+      security_credential:
+        "kxlZ1Twlfr6xQru0GId03LbegvuTPelnz3qITkvUJxaCTQt1HaD2hN801Pgbi38x6dEq/hsanBBtfj6JbePayipE/srOyMQ61ieiO+5uHb/JX/NLi1Jy6Alvi0hKbCbq9cVwC/bZBhli7AUAtpfKVgIyXq2InNyfzXpzR8FhrbXiaMhTPJ8WleozPm5CnXe2bFlFP7K0yhCRlT+UOPl7xh0LqU23rMTj3TN/ms600c3j/m2FxQZdmY5/rdORrJeTQV1vw6kXr1QrGaSDSdRMUiaGbg5uPL8LSNwC5bn3M92oPY2cWmkyH9rOzbCN+o5+23TvweaKZlrKuv7etKXMFg=="
     ]
   ]

--- a/lib/ex_pesa/Mpesa/account_balance.ex
+++ b/lib/ex_pesa/Mpesa/account_balance.ex
@@ -58,7 +58,7 @@ defmodule ExPesa.Mpesa.AccountBalance do
     end
   end
 
-  def account_balance(security_credential) do
+  defp account_balance(security_credential) do
     payload = %{
       "Initiator" => Application.get_env(:ex_pesa, :mpesa)[:balance][:initiator_name],
       "SecurityCredential" => security_credential,

--- a/lib/ex_pesa/Mpesa/account_balance.ex
+++ b/lib/ex_pesa/Mpesa/account_balance.ex
@@ -19,6 +19,7 @@ defmodule ExPesa.Mpesa.AccountBalance do
         mpesa: [
             cert: "",
             balance: [
+                short_code: "",
                 initiator_name: "Safaricom1",
                 password: "Safaricom133",
                 timeout_url: "",
@@ -38,17 +39,9 @@ defmodule ExPesa.Mpesa.AccountBalance do
       - production - set password from the organization portal.
       - sandbox - use your own custom password
 
-  ## Parameters
-
-  attrs: - a map containing:
-  - `command_id` - A unique command passed to the M-Pesa system..
-  - `short_code` - The shortcode of the organisation receiving the transaction.
-  - `remarks` - Comments that are sent along with the transaction.
-  - `account_type` - Organisation receiving the funds.
-
   ## Example
 
-      iex> ExPesa.Mpesa.AccountBalance.request(%{command_id: "AccountBalance", short_code: "602843", remarks: "remarks", account_type: "Customer"})
+      iex> ExPesa.Mpesa.AccountBalance.request()
       {:ok,
         %{
             "ConversationID" => "AG_20201010_00007d6021022d396df6",
@@ -57,34 +50,22 @@ defmodule ExPesa.Mpesa.AccountBalance do
             "ResponseDescription" => "Accept the service request successfully."
         }}
   """
-  @spec request(map()) :: {:error, any()} | {:ok, any()}
-  def request(params) do
+
+  def request() do
     case get_security_credential_for(:balance) do
       nil -> {:error, "cannot generate security_credential due to missing configuration fields"}
-      security_credential -> account_balance(security_credential, params)
+      security_credential -> account_balance(security_credential)
     end
   end
 
-  @doc false
-  def request() do
-    {:error,
-     "Required Parameter missing, 'command_id','short_code', 'remarks','account_reference'"}
-  end
-
-  def account_balance(security_credential, %{
-        command_id: command_id,
-        short_code: short_code,
-        remarks: remarks,
-        account_type: account_type
-      }) do
+  def account_balance(security_credential) do
     payload = %{
       "Initiator" => Application.get_env(:ex_pesa, :mpesa)[:balance][:initiator_name],
       "SecurityCredential" => security_credential,
-      "CommandID" => command_id,
-      "PartyA" => short_code,
+      "CommandID" => "AccountBalance",
+      "PartyA" => Application.get_env(:ex_pesa, :mpesa)[:balance][:short_code],
       "IdentifierType" => 4,
-      "Remarks" => remarks,
-      "AccountType" => account_type,
+      "Remarks" => "Checking account balance",
       "QueueTimeOutURL" => Application.get_env(:ex_pesa, :mpesa)[:balance][:timeout_url],
       "ResultURL" => Application.get_env(:ex_pesa, :mpesa)[:balance][:result_url]
     }

--- a/lib/ex_pesa/Mpesa/b2b.ex
+++ b/lib/ex_pesa/Mpesa/b2b.ex
@@ -93,7 +93,6 @@ defmodule ExPesa.Mpesa.B2B do
     end
   end
 
-<<<<<<< HEAD
   defp b2b_request(
          security_credential,
          %{
@@ -104,12 +103,6 @@ defmodule ExPesa.Mpesa.B2B do
          } = params
        ) do
     account_reference = Map.get(params, :account_reference, nil)
-=======
-  def request() do
-    {:error,
-     "Required Parameter missing, 'command_id','amount','receiver_party', 'remarks','account_reference'"}
-  end
->>>>>>> b1b9015...  added acount balance
 
     payload = %{
       "Initiator" => Application.get_env(:ex_pesa, :mpesa)[:b2b][:initiator_name],

--- a/test/ex_pesa/Mpesa/account_balance_test.exs
+++ b/test/ex_pesa/Mpesa/account_balance_test.exs
@@ -42,23 +42,9 @@ defmodule ExPesa.Mpesa.AccountBalanceTest do
 
   describe "Mpesa AccountBalance" do
     test "request/1 should Initiate a AccountBalance request" do
-      payment_details = %{
-        command_id: "AccountBalance",
-        short_code: "602843",
-        remarks: "remarks",
-        account_type: "Customer"
-      }
-
-      {:ok, result} = AccountBalance.request(payment_details)
+      {:ok, result} = AccountBalance.request()
 
       assert result["ResponseCode"] == "0"
-    end
-
-    test "request/1 should error out without required parameter" do
-      {:error, result} = AccountBalance.request()
-
-      "Required Parameter missing, 'command_id','short_code', 'remarks','account_reference'" =
-        result
     end
   end
 end


### PR DESCRIPTION
## What is the Purpose?

The Account Balance API requests for the account balance of a short code.

## Testing
### Configs
```elixir
    config :ex_pesa,
        mpesa: [
            cert: "",
            balance: [
                initiator_name: "Safaricom1",
                password: "Safaricom133",
                timeout_url: "",
                result_url: "",
                security_credential: ""
            ]
        ]
  ```
then ... 
`ExPesa.Mpesa.AccountBalance.request(%{command_id: "AccountBalance", short_code: "602843", remarks: "remarks", account_type: "Customer"})`