### PR TITLE
Account Inquiry - Pesalink Banks

### DIFF
--- a/lib/ex_pesa/Jenga/send_money_queries/account_inquiry_pesalink_banks.ex
+++ b/lib/ex_pesa/Jenga/send_money_queries/account_inquiry_pesalink_banks.ex
@@ -1,0 +1,39 @@
+defmodule ExPesa.Jenga.SendMoneyQueries.AccountInquiryPesalinkBanks do
+  @moduledoc """
+  This webservice returns the recipients’ Linked Banks linked to the provided phone number on PesaLink
+  """
+
+  import ExPesa.Jenga.JengaBase
+
+  @doc """
+  Inquire about the recipients linked banks tied to a given phone number
+    Read more about Pesalink participating banks here: https://developer.jengaapi.io/reference#account-inquiry-pesalink-banks
+
+  ## Parameters
+
+  attrs: - a map containing:
+    - `mobileNumber` [string] - recipients mobile number eg 0763000000
+
+  ## Example
+      iex> ExPesa.Jenga.SendMoneyQueries.AccountInquiryPesalinkBanks.request(%{ mobileNumber: "0722000000"})
+      {:ok,
+        %{
+          "banks" => [
+            %{"bankCode" => "31", "bankName" => "Stanbic", "customerName" => "John Doe"}
+          ]
+        }
+      }
+  """
+  @spec request(map()) :: {:error, any()} | {:ok, any()}
+  def request(
+        %{
+          mobileNumber: _t
+        } = requestBody
+      ) do
+    make_request("/transaction/v2/pesalink/inquire", requestBody)
+  end
+
+  def request(_) do
+    {:error, "Required Parameters missing, check your request body"}
+  end
+end

--- a/lib/ex_pesa/Jenga/send_money_queries/account_inquiry_pesalink_banks.ex
+++ b/lib/ex_pesa/Jenga/send_money_queries/account_inquiry_pesalink_banks.ex
@@ -24,7 +24,7 @@ defmodule ExPesa.Jenga.SendMoneyQueries.AccountInquiryPesalinkBanks do
         }
       }
   """
-  @spec request(map()) :: {:error, any()} | {:ok, any()}
+  @spec request(map()) :: {:error, any()} | {:ok, map()}
   def request(
         %{
           mobileNumber: _t

--- a/test/ex_pesa/Jenga/send_money_queries/account_inquiry_pesalink_banks_test.exs
+++ b/test/ex_pesa/Jenga/send_money_queries/account_inquiry_pesalink_banks_test.exs
@@ -1,0 +1,57 @@
+defmodule ExPesa.Jenga.SendMoneyQueries.AccountInquiryPesalinkBanksTest do
+  @moduledoc false
+
+  use ExUnit.Case, async: true
+
+  import Tesla.Mock
+
+  alias ExPesa.Jenga.SendMoneyQueries.AccountInquiryPesalinkBanks
+
+  setup do
+    mock(fn
+      %{
+        url: "https://uat.jengahq.io/identity/v2/token",
+        method: :post
+      } ->
+        %Tesla.Env{
+          status: 200,
+          body: """
+          {
+            "access_token" : "SGWcJPtNtYNPGm6uSYR9yPYrAI3Bm",
+            "expires_in" : "3599"
+          }
+          """
+        }
+
+      %{url: "https://uat.jengahq.io/transaction/v2/pesalink/inquire", method: :post} ->
+        %Tesla.Env{
+          status: 200,
+          body: %{
+            "banks" => [
+              %{"bankCode" => "31", "bankName" => "Stanbic", "customerName" => "John Doe"}
+            ]
+          }
+        }
+    end)
+
+    :ok
+  end
+
+  describe "Account Inquiry - Pesalink Banks" do
+    test "request/1 inquire about linked account" do
+      request_body = %{mobileNumber: "0722000000"}
+
+      {:ok, result} = AccountInquiryPesalinkBanks.request(request_body)
+
+      assert result["banks"] == [
+               %{"bankCode" => "31", "bankName" => "Stanbic", "customerName" => "John Doe"}
+             ]
+    end
+
+    test "request/1 fail with no parameters passed" do
+      {:error, message} = AccountInquiryPesalinkBanks.request("request_details")
+
+      assert message == "Required Parameters missing, check your request body"
+    end
+  end
+end


### PR DESCRIPTION
## What is the Purpose?

This PR adds Account Inquiry - Pesalink Banks which returns the recipients’ Linked Banks linked to the provided phone number on PesaLink

## Issue(s) affected?

List of issues addressed by this PR.
